### PR TITLE
Add missing include <cstdint>

### DIFF
--- a/src/svaba/Histogram.h
+++ b/src/svaba/Histogram.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 #include <fstream>
+#include <cstdint>
 
 #include "SeqLib/IntervalTree.h"
 


### PR DESCRIPTION
Required for compilation on my system, throws error otherwise:
```cpp
In file included from /resources/github/svaba/src/svaba/Histogram.cpp:1:
/resources/github/svaba/src/svaba/Histogram.h:104:61: error: ‘uint32_t’ does not name a type
  104 |   Histogram(const int32_t& start, const int32_t& end, const uint32_t& width);
      |                                                             ^~~~~~~~
```